### PR TITLE
Add URL

### DIFF
--- a/apache2/config.json
+++ b/apache2/config.json
@@ -3,6 +3,7 @@
     "version": "1.2.0",
     "slug": "apache2",
     "description": "Apache2 Webserver Addon ",
+    "url": "https://github.com/FaserF/hassio-addons/tree/master/apache2",
     "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
     "startup": "application",
     "boot": "auto",


### PR DESCRIPTION
Adding the url makes sure that the `Visit Apache2 page for details.` link referes to the the github page.