### PR TITLE
[Netboot.xyz] Add missing dependency and fix execution rights

### DIFF
--- a/netboot-xyz/Dockerfile
+++ b/netboot-xyz/Dockerfile
@@ -7,6 +7,7 @@ ARG NETBOOTXYZ_VERSION="0.7.0"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
+    dnsmasq \
     nginx \
     nodejs \
     tftp-hpa && \
@@ -29,6 +30,9 @@ COPY root/ /
 
 # app runs on port 3000
 EXPOSE 3000
+
+# Ensure all run files from the services are executable
+RUN chmod a+x /etc/services.d/*/run
 
 # Configure DNSMASQ
 RUN chmod a+x /etc/cont-init.d/*


### PR DESCRIPTION
# Proposed Changes

* Add dnsmasq dependency
* Ensure all run files from the services are executable

## Related Issues

https://github.com/FaserF/hassio-addons/issues/232

## Note

First time trying to fix or tweak a HomeAssistant addon, I'm not really sure if it works. I wouldn't mind if people check on their side