### PR TITLE
add php82-xmlwriter extension

### DIFF
--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 RUN mkdir /run/apache2
 
 RUN apk --no-cache add apache2 php82-apache2 libxml2-dev apache2-utils apache2-mod-wsgi apache2-ssl
-RUN apk --no-cache add php82 php82-dev php82-fpm php82-mysqli php82-opcache php82-gd zlib php82-curl php82-phar php82-mbstring php82-zip php82-pdo php82-pdo_mysql php82-iconv php82-dom php82-session php82-intl php82-soap php82-fileinfo php82-xml php82-ctype php82-pecl-xdebug php82-pdo_sqlite php82-tokenizer php82-exif
+RUN apk --no-cache add php82 php82-dev php82-fpm php82-mysqli php82-opcache php82-gd zlib php82-curl php82-phar php82-mbstring php82-zip php82-pdo php82-pdo_mysql php82-iconv php82-dom php82-session php82-intl php82-soap php82-fileinfo php82-xml php82-ctype php82-pecl-xdebug php82-pdo_sqlite php82-tokenizer php82-exif php82-xmlwriter
 RUN apk --no-cache add mosquitto mosquitto-dev
 RUN apk --no-cache add mariadb-client
 RUN apk --no-cache add ffmpeg


### PR DESCRIPTION
# Proposed Changes

add php82-xmlwriter extension

## Related Issues

> None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced PHP support by adding the `php82-xmlwriter` package for improved XML writing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->