### PR TITLE
eneble_rewrite even without HTTPS

### DIFF
--- a/apache2/run.sh
+++ b/apache2/run.sh
@@ -62,6 +62,8 @@ if [ $phpini != "default" ]; then
 	fi
 fi
 
+	sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf
+
 if [ $ssl = "true" ] && [ $default_conf = "default" ]; then
 	echo "You have activated SSL. SSL Settings will be applied"
 	if [ ! -f /ssl/$certfile ]; then
@@ -73,7 +75,6 @@ if [ $ssl = "true" ] && [ $default_conf = "default" ]; then
 		exit 1
 	fi
 	mkdir /etc/apache2/sites-enabled
-	sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf
 	echo "Listen 8099" >>/etc/apache2/httpd.conf
 	echo "<VirtualHost *:80>" >/etc/apache2/sites-enabled/000-default.conf
 	echo "ServerName $website_name" >>/etc/apache2/sites-enabled/000-default.conf


### PR DESCRIPTION
Move eneble_rewrite apache to be enabled without ssl

# Proposed Changes

> To allow apache rewrite module be enabled without ssl

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SSL handling and configuration management for Apache web server.
	- Added HTTP to HTTPS redirection for improved security.
	- Improved user feedback during the setup process.

- **Bug Fixes**
	- Addressed redundancy in the configuration script related to URL rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->