### PR TITLE
Apache: Add new PHP extensions to support Prestashop

### DIFF
--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -7,11 +7,12 @@ RUN mkdir /run/apache2
 
 RUN apk --no-cache add apache2 php83-apache2 libxml2-dev apache2-utils apache2-mod-wsgi apache2-ssl
 RUN apk --no-cache add php83 php83-dev php83-fpm php83-mysqli php83-opcache php83-gd zlib php83-curl php83-phar php83-mbstring php83-zip php83-pdo php83-pdo_mysql php83-iconv php83-dom php83-session php83-intl php83-soap php83-fileinfo php83-xml php83-ctype php83-pecl-xdebug php83-pdo_sqlite php83-tokenizer php83-exif php83-xmlwriter php83-cgi
-RUN apk --no-cache add php83-simplexml 
-RUN apk --no-cache add php83-gd php83-json 
-#RUN apk --no-cache add php83-php_posix 
-RUN apk --no-cache add php83-imap 
-RUN apk --no-cache add php83-apcu
+RUN apk --no-cache add \
+    php83-simplexml \
+    php83-gd \
+    php83-json \
+    php83-imap \
+    php83-apcu
 RUN apk --no-cache add mosquitto mosquitto-dev
 RUN apk --no-cache add mariadb-client
 RUN apk --no-cache add ffmpeg

--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -7,6 +7,11 @@ RUN mkdir /run/apache2
 
 RUN apk --no-cache add apache2 php83-apache2 libxml2-dev apache2-utils apache2-mod-wsgi apache2-ssl
 RUN apk --no-cache add php83 php83-dev php83-fpm php83-mysqli php83-opcache php83-gd zlib php83-curl php83-phar php83-mbstring php83-zip php83-pdo php83-pdo_mysql php83-iconv php83-dom php83-session php83-intl php83-soap php83-fileinfo php83-xml php83-ctype php83-pecl-xdebug php83-pdo_sqlite php83-tokenizer php83-exif php83-xmlwriter php83-cgi
+RUN apk --no-cache add php83-simplexml 
+RUN apk --no-cache add php83-gd php83-json 
+#RUN apk --no-cache add php83-php_posix 
+RUN apk --no-cache add php83-imap 
+RUN apk --no-cache add php83-apcu
 RUN apk --no-cache add mosquitto mosquitto-dev
 RUN apk --no-cache add mariadb-client
 RUN apk --no-cache add ffmpeg


### PR DESCRIPTION
Add PHP extension to be allowed run Prestashop 8.2 app

# Proposed Changes

> Add PHP extension to be allowed run Prestashop 8.2 app

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced PHP environment with additional packages for improved functionality.

- **Improvements**
	- Refined Dockerfile structure for better readability and organization.
	- Updated logging configuration for Apache to improve error tracking.

- **Chores**
	- Removed redundant package to streamline the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->