### PR TITLE
[Wiki.JS] [fix] Update addon_config permissions

### DIFF
--- a/wiki.js/config.yaml
+++ b/wiki.js/config.yaml
@@ -12,7 +12,8 @@ services:
   - mysql:need
 map:
   - ssl
-  - addon_config
+  - type: addon_config
+    read_only: false
 ingress: true
 ingress_port: 3010
 init: false


### PR DESCRIPTION
# Proposed Changes

Update the addon config map to allow write permission to fix startup.

## Related Issues

#662 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Restructured addon configuration format to use structured settings instead of inline values, including an explicit read-only flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->