### PR TITLE
feat: allow polls with multiple replies

### DIFF
--- a/whatsapp/app/src/routes/api.js
+++ b/whatsapp/app/src/routes/api.js
@@ -210,14 +210,29 @@ export function registerAPIRoutes(app) {
 
   app.post('/send_poll', authMiddleware, async (req, res) => {
     const session = getReqSession(req);
-    const { number, question, options, quotedMessageId, expiration } = req.body;
+    const { number, question, options, quotedMessageId, expiration, selectableCount } = req.body;
     if (!session.isConnected) return res.status(503).json({ detail: 'Not connected' });
     const quoted = getQuotedMessage(session, quotedMessageId);
     try {
       const jid = getJid(number);
+      let normalizedSelectableCount =
+        selectableCount === undefined || selectableCount === null ? 1 : Number(selectableCount);
+      if (
+        !Number.isInteger(normalizedSelectableCount) ||
+        normalizedSelectableCount < 0 ||
+        normalizedSelectableCount > options.length
+      ) {
+        normalizedSelectableCount = 1;
+      }
       const sentMsg = await session.sock.sendMessage(
         jid,
-        { poll: { name: question, values: options, selectableCount: 1 } },
+        {
+          poll: {
+            name: question,
+            values: options,
+            selectableCount: normalizedSelectableCount,
+          },
+        },
         { quoted, ephemeralExpiration: expiration }
       );
       session.messageStore.set(sentMsg.key.id, sentMsg);


### PR DESCRIPTION
# Proposed Changes

Allow user to set selectableCount to control if WhatsApp poll can have multiple responses

## Related Issues

https://github.com/FaserF/ha-whatsapp/pull/34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poll sending functionality now supports customizable selection limits. Users can specify the exact number of options that respondents are allowed to select when sending a poll. The system automatically validates this configuration to ensure the count remains valid and within the constraints of the poll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->