### PR TITLE
fix poll multiple option send

### DIFF
--- a/whatsapp/app/src/routes/api/messaging.js
+++ b/whatsapp/app/src/routes/api/messaging.js
@@ -110,7 +110,7 @@ export function registerMessagingRoutes(app) {
           poll: {
             name: pollTitle,
             values: cleanedOptions,
-            selectableCount: selectableCount || 1,
+            selectableCount: selectableCount ??  1,
           },
         });
         trackSent(session, number, `[Poll] ${pollTitle}`);


### PR DESCRIPTION
passing 0 to enable multi choice polls is ignored due to || operator treating 0 as false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Polls now preserve an explicitly configured selectable count of `0`; the default value is used only when the count is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->